### PR TITLE
ensure the existence of the directory we should be installing into

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ echo "Updating submodules..."
 git submodule update --init
 
 echo "Creating symlinks..."
+mkdir -p ~/Library/Application\ Support/com.ridiculousfish.HexFiend/Templates
 ln -sf "$SCRIPT_DIR/Mac ROM.tcl" ~/Library/Application\ Support/com.ridiculousfish.HexFiend/Templates
 ln -sf "$SCRIPT_DIR/rom_maps" ~/Library/Application\ Support/com.ridiculousfish.HexFiend/Templates
 


### PR DESCRIPTION
Per demik's post here:

https://68kmla.org/bb/index.php?threads/rom-fiend-a-declrom-extended-declrom-and-system-rom-parser.46053/#post-512919

this creates the template directory if it (or something on the path to it) isn't there.  It does not complain if the directory already exists.